### PR TITLE
Register kubeconfig flag variable via RegisterFlags func

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllerruntime
 
 import (
+	"flag"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -148,3 +150,7 @@ var (
 	// SetLogger sets a concrete logging implementation for all deferred Loggers.
 	SetLogger = log.SetLogger
 )
+
+func init() {
+	config.RegisterFlags(flag.NewFlagSet("controller-runtime", flag.ExitOnError))
+}

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -34,9 +34,9 @@ var (
 	log        = logf.RuntimeLog.WithName("client").WithName("config")
 )
 
-func init() {
-	// TODO: Fix this to allow double vendoring this library but still register flags on behalf of users
-	flag.StringVar(&kubeconfig, "kubeconfig", "",
+// RegisterFlags registers the kubeconfig flag variable to the given FlagSet.
+func RegisterFlags(flags *flag.FlagSet) {
+	flags.StringVar(&kubeconfig, "kubeconfig", "",
 		"Paths to a kubeconfig. Only required if out-of-cluster.")
 }
 


### PR DESCRIPTION
Signed-off-by: Frey, Johannes (415) <johannes.frey@mercedes-benz.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
